### PR TITLE
Android security 11.0.0 release 64

### DIFF
--- a/src/com/android/settings/bluetooth/BluetoothSwitchPreferenceController.java
+++ b/src/com/android/settings/bluetooth/BluetoothSwitchPreferenceController.java
@@ -45,6 +45,7 @@ public class BluetoothSwitchPreferenceController
     private SwitchWidgetController mSwitch;
     private Context mContext;
     private FooterPreference mFooterPreference;
+    private boolean mIsAlwaysDiscoverable;
 
     @VisibleForTesting
     AlwaysDiscoverable mAlwaysDiscoverable;
@@ -78,7 +79,9 @@ public class BluetoothSwitchPreferenceController
     @Override
     public void onStart() {
         mBluetoothEnabler.resume(mContext);
-        mAlwaysDiscoverable.start();
+        if (mIsAlwaysDiscoverable) {
+            mAlwaysDiscoverable.start();
+        }
         if (mSwitch != null) {
             updateText(mSwitch.isChecked());
         }
@@ -87,7 +90,19 @@ public class BluetoothSwitchPreferenceController
     @Override
     public void onStop() {
         mBluetoothEnabler.pause();
-        mAlwaysDiscoverable.stop();
+        if (mIsAlwaysDiscoverable) {
+            mAlwaysDiscoverable.stop();
+        }
+    }
+
+    /**
+     * Set whether the device can be discovered. By default the value will be {@code false}.
+     *
+     * @param isAlwaysDiscoverable {@code true} if the device can be discovered,
+     *     otherwise {@code false}
+     */
+    public void setAlwaysDiscoverable(boolean isAlwaysDiscoverable) {
+        mIsAlwaysDiscoverable = isAlwaysDiscoverable;
     }
 
     @Override

--- a/src/com/android/settings/connecteddevice/BluetoothDashboardFragment.java
+++ b/src/com/android/settings/connecteddevice/BluetoothDashboardFragment.java
@@ -18,12 +18,17 @@ package com.android.settings.connecteddevice;
 import android.app.settings.SettingsEnums;
 import android.content.Context;
 import android.os.Bundle;
+import android.text.TextUtils;
+import android.util.Log;
+
+import androidx.annotation.VisibleForTesting;
 
 import com.android.settings.R;
 import com.android.settings.SettingsActivity;
 import com.android.settings.bluetooth.BluetoothDeviceRenamePreferenceController;
 import com.android.settings.bluetooth.BluetoothSwitchPreferenceController;
 import com.android.settings.dashboard.DashboardFragment;
+import com.android.settings.password.PasswordUtils;
 import com.android.settings.search.BaseSearchIndexProvider;
 import com.android.settings.widget.SwitchBar;
 import com.android.settings.widget.SwitchBarController;
@@ -40,6 +45,10 @@ public class BluetoothDashboardFragment extends DashboardFragment {
 
     private static final String TAG = "BluetoothDashboardFrag";
     private static final String KEY_BLUETOOTH_SCREEN_FOOTER = "bluetooth_screen_footer";
+    private static final String SETTINGS_PACKAGE_NAME = "com.android.settings";
+    private static final String SYSTEMUI_PACKAGE_NAME = "com.android.systemui";
+    private static final String SLICE_ACTION = "com.android.settings.SEARCH_RESULT_TRAMPOLINE";
+    private static final boolean DEBUG = Log.isLoggable(TAG, Log.DEBUG);
 
     private FooterPreference mFooterPreference;
     private SwitchBar mSwitchBar;
@@ -80,16 +89,32 @@ public class BluetoothDashboardFragment extends DashboardFragment {
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
+        String callingAppPackageName = PasswordUtils.getCallingAppPackageName(
+                getActivity().getActivityToken());
+        String action = getIntent() != null ? getIntent().getAction() : "";
+        if (DEBUG) {
+            Log.d(TAG, "onActivityCreated() calling package name is : " + callingAppPackageName
+                    + ", action : " + action);
+        }
 
         SettingsActivity activity = (SettingsActivity) getActivity();
         mSwitchBar = activity.getSwitchBar();
         mController = new BluetoothSwitchPreferenceController(activity,
                 new SwitchBarController(mSwitchBar), mFooterPreference);
+        mController.setAlwaysDiscoverable(isAlwaysDiscoverable(callingAppPackageName, action));
         Lifecycle lifecycle = getSettingsLifecycle();
         if (lifecycle != null) {
             lifecycle.addObserver(mController);
         }
     }
+
+    @VisibleForTesting
+    boolean isAlwaysDiscoverable(String callingAppPackageName, String action) {
+        return TextUtils.equals(SLICE_ACTION, action) ? false
+            : TextUtils.equals(SETTINGS_PACKAGE_NAME, callingAppPackageName)
+                || TextUtils.equals(SYSTEMUI_PACKAGE_NAME, callingAppPackageName);
+    }
+
     /**
      * For Search.
      */

--- a/tests/robotests/src/com/android/settings/bluetooth/BluetoothSwitchPreferenceControllerTest.java
+++ b/tests/robotests/src/com/android/settings/bluetooth/BluetoothSwitchPreferenceControllerTest.java
@@ -18,13 +18,14 @@ package com.android.settings.bluetooth;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import android.content.Context;
 import android.provider.Settings;
-
 import android.text.TextUtils;
+
 import com.android.settings.R;
 import com.android.settings.testutils.FakeFeatureFactory;
 import com.android.settings.utils.AnnotationSpan;
@@ -109,16 +110,34 @@ public class BluetoothSwitchPreferenceControllerTest {
     }
 
     @Test
-    public void onStart_shouldStartAlwaysDiscoverable() {
+    public void onStart_setAlwaysDiscoverableAsTrue_shouldStartAlwaysDiscoverable() {
+        mController.setAlwaysDiscoverable(true);
         mController.onStart();
 
         verify(mAlwaysDiscoverable).start();
     }
 
     @Test
-    public void onStop_shouldStopAlwaysDiscoverable() {
+    public void onStart_setAlwaysDiscoverableAsFalse_shouldStartAlwaysDiscoverable() {
+        mController.setAlwaysDiscoverable(false);
+        mController.onStart();
+
+        verify(mAlwaysDiscoverable, never()).start();
+    }
+
+    @Test
+    public void onStop_setAlwaysDiscoverableAsTrue_shouldStopAlwaysDiscoverable() {
+        mController.setAlwaysDiscoverable(true);
         mController.onStop();
 
         verify(mAlwaysDiscoverable).stop();
+    }
+
+    @Test
+    public void onStop__setAlwaysDiscoverableAsFalse_shouldStopAlwaysDiscoverable() {
+        mController.setAlwaysDiscoverable(false);
+        mController.onStop();
+
+        verify(mAlwaysDiscoverable, never()).stop();
     }
 }

--- a/tests/robotests/src/com/android/settings/connecteddevice/BluetoothDashboardFragmentTest.java
+++ b/tests/robotests/src/com/android/settings/connecteddevice/BluetoothDashboardFragmentTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.settings.connecteddevice;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+@RunWith(RobolectricTestRunner.class)
+public class BluetoothDashboardFragmentTest {
+    private static final String SETTINGS_PACKAGE_NAME = "com.android.settings";
+    private static final String SYSTEMUI_PACKAGE_NAME = "com.android.systemui";
+    private static final String SLICE_ACTION = "com.android.settings.SEARCH_RESULT_TRAMPOLINE";
+    private static final String TEST_APP_NAME = "com.testapp.settings";
+    private static final String TEST_ACTION = "com.testapp.settings.ACTION_START";
+
+    private BluetoothDashboardFragment mFragment;
+
+    @Before
+    public void setUp() {
+        mFragment = new BluetoothDashboardFragment();
+    }
+
+
+    @Test
+    public void isAlwaysDiscoverable_callingAppIsNotFromSystemApp_returnsFalse() {
+        assertThat(mFragment.isAlwaysDiscoverable(TEST_APP_NAME, TEST_ACTION)).isFalse();
+    }
+
+    @Test
+    public void isAlwaysDiscoverable_callingAppIsFromSettings_returnsTrue() {
+        assertThat(mFragment.isAlwaysDiscoverable(SETTINGS_PACKAGE_NAME, TEST_ACTION)).isTrue();
+    }
+
+    @Test
+    public void isAlwaysDiscoverable_callingAppIsFromSystemUI_returnsTrue() {
+        assertThat(mFragment.isAlwaysDiscoverable(SYSTEMUI_PACKAGE_NAME, TEST_ACTION)).isTrue();
+    }
+
+    @Test
+    public void isAlwaysDiscoverable_actionIsFromSlice_returnsFalse() {
+        assertThat(mFragment.isAlwaysDiscoverable(SYSTEMUI_PACKAGE_NAME, SLICE_ACTION)).isFalse();
+    }
+}


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r64' of https://android.googlesource.com/platform/packages/apps/Settings into arrow-11.0

Android security 11.0.0 release 64
Tag: https://android.googlesource.com/platform/packages/apps/Settings/+/refs/tags/android-security-11.0.0_r64

Merge cherrypicks of ['ag/20419569'] into security-aosp-rvc-release.

Change-Id: [I6ad417bb0dab666e3119f7f214913b677e450b55](https://android-review.googlesource.com/#/q/I6ad417bb0dab666e3119f7f214913b677e450b55)