### PR TITLE
Android security 11.0.0 release 65

### DIFF
--- a/src/com/android/settings/SettingsPreferenceFragment.java
+++ b/src/com/android/settings/SettingsPreferenceFragment.java
@@ -55,6 +55,8 @@ import com.android.settingslib.core.instrumentation.Instrumentable;
 import com.android.settingslib.search.Indexable;
 import com.android.settingslib.widget.LayoutPreference;
 
+import com.google.android.setupcompat.util.WizardManagerHelper;
+
 import java.util.UUID;
 
 /**
@@ -63,7 +65,7 @@ import java.util.UUID;
 public abstract class SettingsPreferenceFragment extends InstrumentedPreferenceFragment
         implements DialogCreatable, HelpResourceProvider, Indexable {
 
-    private static final String TAG = "SettingsPreference";
+    private static final String TAG = "SettingsPreferenceFragment";
 
     private static final String SAVE_HIGHLIGHTED_KEY = "android:preference_highlighted";
 
@@ -122,6 +124,15 @@ public abstract class SettingsPreferenceFragment extends InstrumentedPreferenceF
     public HighlightablePreferenceGroupAdapter mAdapter;
     @VisibleForTesting
     public boolean mPreferenceHighlighted = false;
+
+    @Override
+    public void onAttach(Context context) {
+        if (shouldSkipForInitialSUW() && !WizardManagerHelper.isDeviceProvisioned(getContext())) {
+            Log.w(TAG, "Skip " + getClass().getSimpleName() + " before SUW completed.");
+            finish();
+        }
+        super.onAttach(context);
+    }
 
     @Override
     public void onCreate(Bundle icicle) {
@@ -268,6 +279,16 @@ public abstract class SettingsPreferenceFragment extends InstrumentedPreferenceF
     protected boolean isPreferenceExpanded(Preference preference) {
         return ((mAdapter == null)
                 || (mAdapter.getPreferenceAdapterPosition(preference) != RecyclerView.NO_POSITION));
+    }
+
+    /**
+     * Whether UI should be skipped in the initial SUW flow.
+     *
+     * @return {@code true} when UI should be skipped in the initial SUW flow.
+     * {@code false} when UI should not be skipped in the initial SUW flow.
+     */
+    protected boolean shouldSkipForInitialSUW() {
+        return false;
     }
 
     protected void onDataSetChanged() {

--- a/src/com/android/settings/accounts/AccountDashboardFragment.java
+++ b/src/com/android/settings/accounts/AccountDashboardFragment.java
@@ -72,6 +72,11 @@ public class AccountDashboardFragment extends DashboardFragment {
         return buildPreferenceControllers(context, this /* parent */, authorities);
     }
 
+    @Override
+    protected boolean shouldSkipForInitialSUW() {
+        return true;
+    }
+
     private static List<AbstractPreferenceController> buildPreferenceControllers(Context context,
             SettingsPreferenceFragment parent, String[] authorities) {
         final List<AbstractPreferenceController> controllers = new ArrayList<>();

--- a/src/com/android/settings/applications/appinfo/AppInfoDashboardFragment.java
+++ b/src/com/android/settings/applications/appinfo/AppInfoDashboardFragment.java
@@ -380,7 +380,13 @@ public class AppInfoDashboardFragment extends DashboardFragment
             return;
         }
         super.onPrepareOptionsMenu(menu);
-        menu.findItem(UNINSTALL_ALL_USERS_MENU).setVisible(shouldShowUninstallForAll(mAppEntry));
+        final MenuItem uninstallAllUsersItem = menu.findItem(UNINSTALL_ALL_USERS_MENU);
+        uninstallAllUsersItem.setVisible(
+                shouldShowUninstallForAll(mAppEntry) && !mAppsControlDisallowedBySystem);
+        if (uninstallAllUsersItem.isVisible()) {
+            RestrictedLockUtilsInternal.setMenuItemAsDisabledByAdmin(getActivity(),
+                    uninstallAllUsersItem, mAppsControlDisallowedAdmin);
+        }
         mUpdatedSysApp = (mAppEntry.info.flags & ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) != 0;
         final MenuItem uninstallUpdatesItem = menu.findItem(UNINSTALL_UPDATES);
         final boolean uninstallUpdateDisabled = getContext().getResources().getBoolean(

--- a/src/com/android/settings/applications/appinfo/AppInfoDashboardFragment.java
+++ b/src/com/android/settings/applications/appinfo/AppInfoDashboardFragment.java
@@ -516,6 +516,11 @@ public class AppInfoDashboardFragment extends DashboardFragment
         return packageName.contains("com.android");
     }
 
+    @Override
+    protected boolean shouldSkipForInitialSUW() {
+        return true;
+    }
+
     private void uninstallPkg(String packageName, boolean allUsers, boolean andDisable) {
         stopListeningToPackageRemove();
         // Create new intent to launch Uninstaller activity

--- a/src/com/android/settings/development/DevelopmentSettingsDashboardFragment.java
+++ b/src/com/android/settings/development/DevelopmentSettingsDashboardFragment.java
@@ -242,6 +242,11 @@ public class DevelopmentSettingsDashboardFragment extends RestrictedDashboardFra
     }
 
     @Override
+    protected boolean shouldSkipForInitialSUW() {
+        return true;
+    }
+
+    @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {
         registerReceivers();

--- a/src/com/android/settings/system/ResetDashboardFragment.java
+++ b/src/com/android/settings/system/ResetDashboardFragment.java
@@ -57,6 +57,11 @@ public class ResetDashboardFragment extends DashboardFragment {
         return buildPreferenceControllers(context, getSettingsLifecycle());
     }
 
+    @Override
+    protected boolean shouldSkipForInitialSUW() {
+        return true;
+    }
+
     private static List<AbstractPreferenceController> buildPreferenceControllers(Context context,
             Lifecycle lifecycle) {
         final List<AbstractPreferenceController> controllers = new ArrayList<>();

--- a/tests/robotests/src/com/android/settings/accounts/AccountDashboardFragmentTest.java
+++ b/tests/robotests/src/com/android/settings/accounts/AccountDashboardFragmentTest.java
@@ -114,4 +114,9 @@ public class AccountDashboardFragmentTest {
 
         assertThat(indexRaws).isNotEmpty();
     }
+
+    @Test
+    public void shouldSkipForInitialSUW_returnTrue() {
+        assertThat(mFragment.shouldSkipForInitialSUW()).isTrue();
+    }
 }

--- a/tests/robotests/src/com/android/settings/applications/appinfo/AppInfoDashboardFragmentTest.java
+++ b/tests/robotests/src/com/android/settings/applications/appinfo/AppInfoDashboardFragmentTest.java
@@ -384,6 +384,11 @@ public final class AppInfoDashboardFragmentTest {
                 .isTrue();
     }
 
+    @Test
+    public void shouldSkipForInitialSUW_returnTrue() {
+        assertThat(mFragment.shouldSkipForInitialSUW()).isTrue();
+    }
+
     @Implements(AppUtils.class)
     public static class ShadowAppUtils {
 

--- a/tests/robotests/src/com/android/settings/development/DevelopmentSettingsDashboardFragmentTest.java
+++ b/tests/robotests/src/com/android/settings/development/DevelopmentSettingsDashboardFragmentTest.java
@@ -276,6 +276,11 @@ public class DevelopmentSettingsDashboardFragmentTest {
         verify(controller).onDisableLogPersistDialogRejected();
     }
 
+    @Test
+    public void shouldSkipForInitialSUW_returnTrue() {
+        assertThat(mDashboard.shouldSkipForInitialSUW()).isTrue();
+    }
+
     @Implements(EnableDevelopmentSettingWarningDialog.class)
     public static class ShadowEnableDevelopmentSettingWarningDialog {
 

--- a/tests/robotests/src/com/android/settings/system/ResetDashboardFragmentTest.java
+++ b/tests/robotests/src/com/android/settings/system/ResetDashboardFragmentTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.system;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class ResetDashboardFragmentTest {
+
+    private ResetDashboardFragment mFragment;
+
+    @Before
+    public void setup() {
+        mFragment = new ResetDashboardFragment();
+    }
+
+    @Test
+    public void shouldSkipForInitialSUW_returnTrue() {
+        assertThat(mFragment.shouldSkipForInitialSUW()).isTrue();
+    }
+}


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r65' of https://android.googlesource.com/platform/packages/apps/Settings into arrow-11.0

Android security 11.0.0 release 65
Tag: https://android.googlesource.com/platform/packages/apps/Settings/+/refs/tags/android-security-11.0.0_r65

Merge cherrypicks of ['ag/20641138', 'ag/20871685'] into security-aosp-rvc-release.

Change-Id: [Iffbc6a2ad8ddbe8180f34ec2c2bfab3deb551091](https://android-review.googlesource.com/#/q/Iffbc6a2ad8ddbe8180f34ec2c2bfab3deb551091)